### PR TITLE
passing a non existing disk to ignoredisk should not halt the installation

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -801,8 +801,7 @@ class IgnoreDisk(commands.ignoredisk.RHEL6_IgnoreDisk):
             if matched:
                 drives.extend(matched)
             else:
-                raise KickstartValueError(formatErrorMsg(self.lineno,
-                        msg=_("Disk \"%s\" given in ignoredisk command does not exist.") % spec))
+                log.warn("Disk \"%s\" given in ignoredisk command does not exist.", spec)
 
         self.ignoredisk = drives
 


### PR DESCRIPTION

I propose this small change to avoid an installation from exploding simply because a disk to ignore doesn't exist. 
Since it allows globs users can specify ignoredisk --drives=/dev/disk/by-path/*usb* if I wish to never install on a usb disk or something similar. But it shouldn't fail since I'm only excluding and if it doesn't exist, it should be ok.